### PR TITLE
JSON input support

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func parseVariables(cmd *cobra.Command, args []string) {
 		} else {
 			jsonBytes, err = ioutil.ReadFile(jsonFileName)
 			if err != nil {
-				fmt.Fprint(cmd.OutOrStderr(), errors.Wrapf(err, "Could not read CSV file %s", key))
+				fmt.Fprint(cmd.OutOrStderr(), errors.Wrapf(err, "Could not read JSON file %s", key))
 				os.Exit(1)
 			}
 		}
@@ -129,7 +129,7 @@ func parseVariables(cmd *cobra.Command, args []string) {
 		jsonMap := make(map[string]interface{})
 		err = json.Unmarshal(jsonBytes, &jsonMap)
 		if err != nil {
-			fmt.Fprint(cmd.OutOrStderr(), errors.Wrapf(err, "Could not parse CSV file %s", jsonFileName))
+			fmt.Fprint(cmd.OutOrStderr(), errors.Wrapf(err, "Could not parse JSON file %s", jsonFileName))
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
This PR adds the following functionalities:
* json input from file
* json input from stdin
  * see: `echo "{\"sample\": \"world\"}" | ./gotmplx --json key=- --eval "sample: {{ .JSON.key.sample }}"`

**Precondition:**
* json files must start with `{` and end with `}`.