### PR TITLE
enhancement: always publish releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ archives:
   - format: binary
 
 release:
-  draft: true
+  draft: false
   prerelease: auto
   name_template: "gotmplx-{{.Tag}}"
 
@@ -37,3 +37,4 @@ changelog:
       - '^ci:'
       - '^cd:'
       - '^ci/cd:'
+      - '^goreleaser:'


### PR DESCRIPTION
Instead of creating drafts, always publish the release after the build.